### PR TITLE
Ignore css and script info

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -7,6 +7,18 @@ class Site
   end
 
   def content
-    Nokogiri::HTML(open url)
+    sanitize
+    html
+  end
+
+  private
+
+  def sanitize
+    html.xpath('//style').remove
+    html.xpath('//script').remove
+  end
+
+  def html
+    @html ||= Nokogiri::HTML(open url)
   end
 end

--- a/app/models/url_words.rb
+++ b/app/models/url_words.rb
@@ -16,11 +16,11 @@ class UrlWords
   private
 
   def site
-    @site ||= Site.new(url: url).content
+    @site ||= Site.new(url: url)
   end
 
   def site_text
-    site.inner_text.downcase.squish
+    site.content.inner_text.downcase.squish
   end
 
   def parsed_site_words

--- a/app/models/url_words.rb
+++ b/app/models/url_words.rb
@@ -20,7 +20,7 @@ class UrlWords
   end
 
   def site_text
-    site.inner_text.squish
+    site.inner_text.downcase.squish
   end
 
   def parsed_site_words

--- a/spec/features/word_search_spec.rb
+++ b/spec/features/word_search_spec.rb
@@ -44,14 +44,24 @@ describe 'new word search' do
       expect(table_rows_plus_header.size).to eq 11
     end
 
-    it 'displays the correct word and frequency count' do
+    it 'displays the correct weighted words and frequency count' do
       first_result_entry = find_all('table tr[2] td')
       expect(first_result_entry.first.text).to eq 'arena'
       expect(first_result_entry.last.text).to eq '31'
 
-      last_result_entry = find_all('table tr:last td')
-      expect(last_result_entry.first.text).to eq 'of'
+      first_result_entry = find_all('table tr[3] td')
+      expect(first_result_entry.first.text).to eq 'the'
+      expect(first_result_entry.last.text).to eq '26'
+
+      last_result_entry = find_all('table tr[10] td')
+      expect(last_result_entry.first.text).to eq 'hockey'
       expect(last_result_entry.last.text).to eq '10'
+
+      last_result_entry = find_all('table tr:last td')
+      #expect(last_result_entry.first.text).to eq 'of'
+      #expect(last_result_entry.last.text).to eq '10'
+      expect(last_result_entry.first.text).to eq 'is'
+      expect(last_result_entry.last.text).to eq '8'
     end
   end
 end


### PR DESCRIPTION
Sanitizes html before sending it to be parsed for words.